### PR TITLE
ビルドエラーを直すためにincludeを追加した

### DIFF
--- a/02_SimpleTriangle/main.cpp
+++ b/02_SimpleTriangle/main.cpp
@@ -1,5 +1,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <stdexcept>
 #include "TriangleApp.h"
 
 const int WINDOW_WIDTH = 640;

--- a/03_TexturedCube/CubeApp.cpp
+++ b/03_TexturedCube/CubeApp.cpp
@@ -1,4 +1,5 @@
-﻿#include "CubeApp.h"
+﻿#include <stdexcept>
+#include "CubeApp.h"
 #define STB_IMAGE_IMPLEMENTATION
 #include "../common/stb_image.h"
 


### PR DESCRIPTION
環境はこちらの通りです。
MSVC = v142(VS2019)
Windows 10 SDK = (10.0.18362.0)
02と03でビルドエラー(std has no member runtime_error)が出たのでincludeを足して修正をしました。
よろしければご確認お願い致します。